### PR TITLE
remove lifecycle hook result variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The available input variables for the module are described in the table below.
 | associate_public_ip_address | `bool` | `false` | Wether to associate public ip address with the instance. Should be false except if bringing a standalone instance for testing. |
 | target_groups_arns | `list(string)` | | List of target group arns in which to register the auto scaling group instances. |
 | health_check_type | `string` | `"ELB"` | Sets the healthcheck type for the auto scaling group. Accepted values ELB, EC2. |
-| asg_lifecycle_hook_default_result | `string` | `"ABANDON"` | Sets the default action for the Auto Scaling group initial lifecycle hook. Can be ABANDON or CONTINUE. |
 | replicated_password | `string` | | Password to set for the replicated console. |
 | tfe_hostname | `string` | | Hostname which will be used to access the tfe instance. |
 | tfe_enc_password | `string` | | Encryption password to be used by TFE. |

--- a/asg_ec2_instance.tf
+++ b/asg_ec2_instance.tf
@@ -39,7 +39,7 @@ resource "aws_launch_configuration" "tfe" {
 }
 
 resource "aws_autoscaling_group" "tfe" {
-  name                      = local.asg_name
+  name                      = "${var.name_prefix}tfe-asg"
   max_size                  = 1
   min_size                  = 1
   health_check_grace_period = 1800

--- a/role.tf
+++ b/role.tf
@@ -32,15 +32,6 @@ data "aws_iam_policy_document" "tfe_instance" {
       "arn:aws:s3:::${var.installation_assets_s3_bucket_name}/*"
     ]
   }
-  statement {
-    sid = "AsgLifecycleHook"
-    actions = [
-      "autoscaling:CompleteLifecycleAction"
-    ]
-    resources = [
-      aws_autoscaling_group.tfe.arn
-    ]
-  }
 }
 
 resource "aws_iam_role_policy" "tfe_instance" {

--- a/templates/install_wrap.sh.tmpl
+++ b/templates/install_wrap.sh.tmpl
@@ -5,10 +5,3 @@ public_ip=$(curl -sSf 'http://169.254.169.254/latest/meta-data/public-ipv4')
 [ -z "$public_ip" ] && public_ip="$private_ip"
 curl -sS -o /tmp/install.sh https://install.terraform.io/ptfe/stable
 bash /tmp/install.sh no-proxy private-address="$private_ip" public-address="$public_ip"
-while ! curl -ksfS --connect-timeout 5 https://127.0.0.1/_health_check; do sleep 5; done
-instance_id=$(curl -sSf 'http://169.254.169.254/latest/meta-data/instance-id')
-region=$(curl -sSf 'http://169.254.169.254/latest/dynamic/instance-identity/document' | jq -r '.region')
-aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
-  --instance-id "$instance_id" --lifecycle-hook-name '${asg_hook}' \
-  --auto-scaling-group-name '${asg_name}' \
-  --region "$region"

--- a/variables.infra.tf
+++ b/variables.infra.tf
@@ -79,9 +79,3 @@ variable "health_check_type" {
   description = "Sets the healthcheck type for the auto scaling group. Accepted values ELB, EC2."
   default     = "ELB"
 }
-
-variable "asg_lifecycle_hook_default_result" {
-  type        = string
-  description = "Sets the default action for the Auto Scaling group initial lifecycle hook. Can be ABANDON or CONTINUE."
-  default     = "ABANDON"
-}


### PR DESCRIPTION
Removed the use of lifecycle hook in the TFE autoscaling group. It is a complication that offers no real benefits. This removes the need for the `asg_lifecycle_hook_default_result` terraform input variable and so it is removed as well.