### PR TITLE
support all possible values in tfe-settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,40 @@ The available input variables for the module are described in the table below.
 | target_groups_arns | `list(string)` | | List of target group arns in which to register the auto scaling group instances. |
 | health_check_type | `string` | `"ELB"` | Sets the healthcheck type for the auto scaling group. Accepted values ELB, EC2. |
 | replicated_password | `string` | | Password to set for the replicated console. |
-| tfe_hostname | `string` | | Hostname which will be used to access the tfe instance. |
-| tfe_enc_password | `string` | | Encryption password to be used by TFE. |
-| tfe_release_sequence | `number` | | The release sequence corresponding to the TFE version which should be installed. |
+| replicated_tls_bootstrap_hostname | `string` | | Hostname which will be used to access the tfe instance. |
+| replicated_tfe_release_sequence | `number` | | The release sequence corresponding to the TFE version which should be installed. |
+| tfe_settings | `map(string)` | | Key/Value pairs to generate the TFE settings file as described on https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#available-settings . The user is responsible to provide all required values that make sense for the type of installation. |
 | installation_assets_s3_bucket_name | `string` | | The name of the S3 bucket containing the installation assets - ssl certificate, ssl certificate key and tfe license. |
 | tfe_license_s3_path | `string` | | S3 Path to the TFE license .rli file. |
 | tfe_cert_s3_path | `string` | | S3 Path to the file containing the certificate chain which should be presented by the TFE. |
 | tfe_privkey_s3_path | `string` | | S3 Path to the file containing the private key for the certificate which should be presented by the TFE. |
-| tfe_ca_bundle | `string` | "``" | The additional CA certificates to add to TFE. Value needs to be a string with new line characters replaced with literal \n. |
-| tfe_pg_address | `string` | | Address of the PostGRE data base to be used by TFE. Must contain hostname and optionally a port. |
-| tfe_pg_dbname | `string` | | Name of the PostGRE data base to be used by TFE. |
-| tfe_pg_user | `string` | | Username tfe will use to access the PostGRE data base. |
-| tfe_pg_password | `string` | | Password tfe will use to access the PostGRE data base. |
-| tfe_s3_bucket | `string` | | Name of the S3 bucket tfe will use for object storage. |
-| tfe_s3_region | `string` | | AWS region of the S3 bucket tfe will use for object storage. |
+
+### Example `tfe_settings` values
+
+These are some examples of the `tfe_settings` value that would make sense in an AWS installation.
+
+**Note:** The value of the `tfe_hostname` input variable is used to set the `TlsBootstrapHostname` parameter in the `replicated.conf` file and not the `hostname` in the `tfe-settings.json` file. That said both values should be the same in most scenarios.
+
+* External services mode - most common and recommended
+
+  ```hcl
+  {
+    installation_type    = "production",
+    production_type      = "external",
+    enc_password         = "very_secret_password",
+    hostname             = "tfe.domain.com",
+    ca_certs             = "ca_certs_string",
+    pg_user              = "postgre_username",
+    pg_password          = "postgre_password",
+    pg_dbname            = "postgre_data_base",
+    pg_netloc            = "postgre_address",
+    pg_extra_params      = "sslmode=require",
+    placement            = "placement_s3",
+    aws_instance_profile = "1",
+    s3_bucket            = "s3_bucket_name",
+    s3_region            = "s3_bucket_region",
+  }
+  ```
 
 ## Outputs
 

--- a/asg_ec2_instance.tf
+++ b/asg_ec2_instance.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_launch_configuration" "tfe" {
-  name_prefix                 = "${var.name_prefix}v${var.tfe_release_sequence}-"
+  name_prefix                 = "${var.name_prefix}v${var.replicated_tfe_release_sequence}-"
   image_id                    = var.ami_id
   instance_type               = var.instance_type
   iam_instance_profile        = aws_iam_instance_profile.tfe_instance.name
@@ -15,9 +15,9 @@ resource "aws_launch_configuration" "tfe" {
   }
   user_data_base64 = base64encode(templatefile("${path.module}/templates/cloud-init.tmpl", {
     replicated_conf_b64content = base64gzip(templatefile("${path.module}/templates/replicated.conf.tmpl", {
-      tfe_hostname         = var.tfe_hostname
+      tfe_hostname         = var.replicated_tls_bootstrap_hostname
       replicated_password  = var.replicated_password
-      tfe_release_sequence = var.tfe_release_sequence
+      tfe_release_sequence = var.replicated_tfe_release_sequence
     }))
     tfe_settings_b64content    = base64gzip(jsonencode(local.tfe_settings))
     install_wrapper_b64content = base64gzip(templatefile("${path.module}/templates/install_wrap.sh.tmpl", {}))

--- a/asg_ec2_instance.tf
+++ b/asg_ec2_instance.tf
@@ -1,3 +1,7 @@
+locals {
+  tfe_settings = { for k, v in var.tfe_settings : k => { "value" = v } }
+}
+
 resource "aws_launch_configuration" "tfe" {
   name_prefix                 = "${var.name_prefix}v${var.tfe_release_sequence}-"
   image_id                    = var.ami_id
@@ -15,17 +19,7 @@ resource "aws_launch_configuration" "tfe" {
       replicated_password  = var.replicated_password
       tfe_release_sequence = var.tfe_release_sequence
     }))
-    tfe_settings_b64content = base64gzip(templatefile("${path.module}/templates/settings.json.tmpl", {
-      tfe_enc_password = var.tfe_enc_password
-      tfe_hostname     = var.tfe_hostname
-      tfe_pg_dbname    = var.tfe_pg_dbname
-      tfe_pg_address   = var.tfe_pg_address
-      tfe_pg_password  = var.tfe_pg_password
-      tfe_pg_user      = var.tfe_pg_user
-      tfe_s3_bucket    = var.tfe_s3_bucket
-      tfe_s3_region    = var.tfe_s3_region
-      tfe_ca_bundle    = var.tfe_ca_bundle
-    }))
+    tfe_settings_b64content    = base64gzip(jsonencode(local.tfe_settings))
     install_wrapper_b64content = base64gzip(templatefile("${path.module}/templates/install_wrap.sh.tmpl", {}))
     download_assets_b64content = base64gzip(templatefile("${path.module}/templates/download_assets.sh.tmpl", {
       tfe_cert_s3_path    = var.tfe_cert_s3_path

--- a/role.tf
+++ b/role.tf
@@ -45,6 +45,6 @@ resource "aws_iam_role_policy" "tfe_instance" {
 }
 
 resource "aws_iam_instance_profile" "tfe_instance" {
-  name  = "${var.name_prefix}tfe-instance"
-  role  = aws_iam_role.tfe_instance.name
+  name = "${var.name_prefix}tfe-instance"
+  role = aws_iam_role.tfe_instance.name
 }

--- a/role.tf
+++ b/role.tf
@@ -1,3 +1,7 @@
+locals {
+  access_s3_storage_via_instance_profile = lookup(var.tfe_settings, "aws_instance_profile", "0") == "1"
+}
+
 resource "aws_iam_role" "tfe_instance" {
   name = "${var.name_prefix}tfe-instance"
 
@@ -26,11 +30,11 @@ data "aws_iam_policy_document" "tfe_instance" {
     actions = [
       "s3:*"
     ]
-    resources = [
-      "arn:aws:s3:::${var.tfe_settings["s3_bucket"]}",
-      "arn:aws:s3:::${var.tfe_settings["s3_bucket"]}/*",
+    resources = compact([
+      local.access_s3_storage_via_instance_profile ? "arn:aws:s3:::${var.tfe_settings["s3_bucket"]}" : "",
+      local.access_s3_storage_via_instance_profile ? "arn:aws:s3:::${var.tfe_settings["s3_bucket"]}/*" : "",
       "arn:aws:s3:::${var.installation_assets_s3_bucket_name}/*"
-    ]
+    ])
   }
 }
 
@@ -41,6 +45,6 @@ resource "aws_iam_role_policy" "tfe_instance" {
 }
 
 resource "aws_iam_instance_profile" "tfe_instance" {
-  name = "${var.name_prefix}tfe-instance"
-  role = aws_iam_role.tfe_instance.name
+  name  = "${var.name_prefix}tfe-instance"
+  role  = aws_iam_role.tfe_instance.name
 }

--- a/role.tf
+++ b/role.tf
@@ -27,8 +27,8 @@ data "aws_iam_policy_document" "tfe_instance" {
       "s3:*"
     ]
     resources = [
-      "arn:aws:s3:::${var.tfe_s3_bucket}",
-      "arn:aws:s3:::${var.tfe_s3_bucket}/*",
+      "arn:aws:s3:::${var.tfe_settings["s3_bucket"]}",
+      "arn:aws:s3:::${var.tfe_settings["s3_bucket"]}/*",
       "arn:aws:s3:::${var.installation_assets_s3_bucket_name}/*"
     ]
   }

--- a/variables.tfe.tf
+++ b/variables.tfe.tf
@@ -3,6 +3,11 @@ variable "replicated_password" {
   description = "Password to set for the replicated console."
 }
 
+variable "replicated_settings" {
+  type        = object(any)
+  description = "The settings provided in the replicated.conf file as defined on  ."
+}
+
 variable "tfe_hostname" {
   type        = string
   description = "Hostname which will be used to access the tfe instance."
@@ -26,6 +31,11 @@ variable "installation_assets_s3_bucket_name" {
 variable "tfe_license_s3_path" {
   type        = string
   description = "S3 Path to the TFE license .rli file."
+}
+
+variable "tfe_settings" {
+  type        = map(string)
+  description = "Key/Value pairs to generate the TFE settings file as described on https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#available-settings ."
 }
 
 variable "tfe_cert_s3_path" {

--- a/variables.tfe.tf
+++ b/variables.tfe.tf
@@ -8,14 +8,14 @@ variable "tfe_hostname" {
   description = "Hostname which will be used to access the tfe instance."
 }
 
-variable "tfe_enc_password" {
-  type        = string
-  description = "Encryption password to be used by TFE."
-}
-
 variable "tfe_release_sequence" {
   type        = number
   description = "The release sequence corresponding to the TFE version which should be installed."
+}
+
+variable "tfe_settings" {
+  type        = map(string)
+  description = "Key/Value pairs to generate the TFE settings file as described on https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#available-settings ."
 }
 
 variable "installation_assets_s3_bucket_name" {
@@ -28,11 +28,6 @@ variable "tfe_license_s3_path" {
   description = "S3 Path to the TFE license .rli file."
 }
 
-variable "tfe_settings" {
-  type        = map(string)
-  description = "Key/Value pairs to generate the TFE settings file as described on https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#available-settings ."
-}
-
 variable "tfe_cert_s3_path" {
   type        = string
   description = "S3 Path to the file containing the certificate chain which should be presented by the TFE."
@@ -41,40 +36,4 @@ variable "tfe_cert_s3_path" {
 variable "tfe_privkey_s3_path" {
   type        = string
   description = "S3 Path to the file containing the private key for the certificate which should be presented by the TFE."
-}
-
-variable "tfe_ca_bundle" {
-  type        = string
-  description = "The additional CA certificates to add to TFE. Value needs to be a string with new line characters replaced with literal \n."
-  default     = ""
-}
-
-variable "tfe_pg_address" {
-  type        = string
-  description = "Address of the PostGRE data base to be used by TFE. Must contain hostname and optionally a port."
-}
-
-variable "tfe_pg_dbname" {
-  type        = string
-  description = "Name of the PostGRE data base to be used by TFE."
-}
-
-variable "tfe_pg_user" {
-  type        = string
-  description = "Username tfe will use to access the PostGRE data base."
-}
-
-variable "tfe_pg_password" {
-  type        = string
-  description = "Password tfe will use to access the PostGRE data base."
-}
-
-variable "tfe_s3_bucket" {
-  type        = string
-  description = "Name of the S3 bucket tfe will use for object storage."
-}
-
-variable "tfe_s3_region" {
-  type        = string
-  description = "AWS region of the S3 bucket tfe will use for object storage."
 }

--- a/variables.tfe.tf
+++ b/variables.tfe.tf
@@ -15,7 +15,7 @@ variable "tfe_release_sequence" {
 
 variable "tfe_settings" {
   type        = map(string)
-  description = "Key/Value pairs to generate the TFE settings file as described on https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#available-settings ."
+  description = "Key/Value pairs to generate the TFE settings file as described on https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#available-settings . The user is responsible to provide all required values that make sense for the type of installation."
 }
 
 variable "installation_assets_s3_bucket_name" {

--- a/variables.tfe.tf
+++ b/variables.tfe.tf
@@ -3,11 +3,6 @@ variable "replicated_password" {
   description = "Password to set for the replicated console."
 }
 
-variable "replicated_settings" {
-  type        = object(any)
-  description = "The settings provided in the replicated.conf file as defined on  ."
-}
-
 variable "tfe_hostname" {
   type        = string
   description = "Hostname which will be used to access the tfe instance."

--- a/variables.tfe.tf
+++ b/variables.tfe.tf
@@ -3,12 +3,12 @@ variable "replicated_password" {
   description = "Password to set for the replicated console."
 }
 
-variable "tfe_hostname" {
+variable "replicated_tls_bootstrap_hostname" {
   type        = string
   description = "Hostname which will be used to access the tfe instance."
 }
 
-variable "tfe_release_sequence" {
+variable "replicated_tfe_release_sequence" {
   type        = number
   description = "The release sequence corresponding to the TFE version which should be installed."
 }


### PR DESCRIPTION
* add `tfe_settings` variable. It takes a map where the key/value pairs are settings provided in the `tfe-settings.json` file. This allows the module supports any settings that can be set there. It also puts the burden of setting all required and appropriate values needed for an AWS installation.
* The EC2 instance IAM role will provide access to the S3 bucket used for TFE object storage dependand on the value of the `aws_instance_profile` key in the `tfe_settings` variable.
* remove the variables previously used to generate the TFE settings - `tfe_ca_bundle`, `tfe_pg_address`, `tfe_pg_dbname`, `tfe_pg_user`, `tfe_pg_password`, `tfe_s3_bucket`, `tfe_s3_region`, `tfe_enc_password`.
* rename variables used to set values in the `replicated.conf` file so that their names indicate the purpose more clearly.
  * `tfe_hostname ` to `replicated_tls_bootstrap_hostname`
  * `tfe_release_sequence ` to `replicated_tfe_release_sequence`